### PR TITLE
add Ignore Committers, Ignore Commits With String features

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ build for branches/tags that match the filter
 * `Required Build Permission` will restrict who can trigger a Jenkins job using the repository permissions
   * This is only available on manual triggers
 * `PR Destination Filter` functions identically to `Ref Filter` but on the branch being merged into
-* `Ignore Committers` list of user names separated by comma (,) Commits from any of these specified users will be 
-ignored and will not trigger any builds
+* `Ignore Committers` list of bitbucket user names separated by new line, Commits from any of these specified users 
+will be ignored and will not trigger any builds
   * This is only available on push event triggers
 * `Ignore Commits With String` If a commit message contains this configured string in it, 
-that commit will be ignored and will not trigger any builds
+that commit will be ignored and will not trigger any builds. Uses java regex syntax
   * This is only available on push event triggers
 
 #### Link your bitbucket server account to Jenkins

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ build for branches/tags that match the filter
 * `Required Build Permission` will restrict who can trigger a Jenkins job using the repository permissions
   * This is only available on manual triggers
 * `PR Destination Filter` functions identically to `Ref Filter` but on the branch being merged into
+* `Ignore Committers` list of user names separated by comma (,) Commits from any of these specified users will be 
+ignored and will not trigger any builds
+  * This is only available on push event triggers
+* `Ignore Commits With String` If a commit message contains this configured string in it, 
+that commit will be ignored and will not trigger any builds
+  * This is only available on push event triggers
 
 #### Link your bitbucket server account to Jenkins
 ![Jenkins user settings](readme/img/jenkins_user.png)  

--- a/parameterized-client/src/hook/job.js
+++ b/parameterized-client/src/hook/job.js
@@ -194,6 +194,19 @@ const JobContainer = ({
                                description={"Trigger builds if matched files are modified (example: \"directory/.*.txt|foobar/.*\"). " +
                                             "Supported triggers: PUSH EVENT, PR OPENED, PR REOPENED, PR SOURCE RESCOPED, PR DEST RESCOPED, PR MERGED, PR DECLINED, PR DELETED"}
                                id={id} jobInfo={jobInfo} errors={errors} updateText={updateText}/>
+
+            <OptionalTextField requiredTriggers={['push;']}
+                               fieldLabel={"Ignore Committers"} fieldName={"ignoreComitters"}
+                               description={"Comma separated list of user names, Commits from these users do not trigger the builds. (example: admin,notifier) " +
+                               "Supported triggers: PUSH EVENT"}
+                               id={id} jobInfo={jobInfo} errors={errors} updateText={updateText}/>
+
+            <OptionalTextField requiredTriggers={['push;']}
+                               fieldLabel={"Ignore Commits With String"} fieldName={"ignoreCommitMsg"}
+                               description={"String to ignore commits if found it in a commit message. (example: SkipCI) " +
+                               "Supported triggers: PUSH EVENT"}
+                               id={id} jobInfo={jobInfo} errors={errors} updateText={updateText}/>
+
             <div className={"field-group" + (jobInfo.active && jobInfo.triggers.includes('manual;') ? "" : " hidden")}>
                 <label htmlFor={"requirePermission-" + id}>Required Build Permission</label>
                 <select id={"requirePermission-" + id} className={"select"} name={"requirePermission-" + id}

--- a/parameterized-client/src/hook/job.js
+++ b/parameterized-client/src/hook/job.js
@@ -195,15 +195,19 @@ const JobContainer = ({
                                             "Supported triggers: PUSH EVENT, PR OPENED, PR REOPENED, PR SOURCE RESCOPED, PR DEST RESCOPED, PR MERGED, PR DECLINED, PR DELETED"}
                                id={id} jobInfo={jobInfo} errors={errors} updateText={updateText}/>
 
-            <OptionalTextField requiredTriggers={['push;']}
-                               fieldLabel={"Ignore Committers"} fieldName={"ignoreComitters"}
-                               description={"Comma separated list of user names, Commits from these users do not trigger the builds. (example: admin,notifier) " +
-                               "Supported triggers: PUSH EVENT"}
-                               id={id} jobInfo={jobInfo} errors={errors} updateText={updateText}/>
+            <div className={"field-group" + (jobInfo.active && jobInfo.triggers.includes('push;') ? "" : " hidden")}>
+                <label htmlFor={"ignoreComitters-" + id}>Ignore Committers</label>
+                <textarea id={"ignoreComitters-" + id} className={"textarea full-width-field"} name={"ignoreComitters-" + id}
+                          value={jobInfo.ignoreComitters} rows={3} onChange={e => {updateText(id, 'ignoreComitters', e.target.value)}}/>
+                <div className={"description"}>
+                    {"List of bitbucket user names separated by new line, Commits from these users do not trigger the builds. " +
+                     "(example: notifier) Supported triggers: PUSH EVENT"}
+                </div>
+            </div>
 
             <OptionalTextField requiredTriggers={['push;']}
                                fieldLabel={"Ignore Commits With String"} fieldName={"ignoreCommitMsg"}
-                               description={"String to ignore commits if found it in a commit message. (example: SkipCI) " +
+                               description={"Regex string to ignore commits if it matches in a commit message. (example: \".*SkipCI.*\") " +
                                "Supported triggers: PUSH EVENT"}
                                id={id} jobInfo={jobInfo} errors={errors} updateText={updateText}/>
 

--- a/parameterized-client/src/hook/state-reducers.js
+++ b/parameterized-client/src/hook/state-reducers.js
@@ -13,6 +13,8 @@ const getInitialState = () => {
         pathRegex: "",
         requirePermission: "REPO_READ",
         prDestinationRegex: "",
+        ignoreComitters: "",
+        ignoreCommitMsg: "",
     }
 };
 
@@ -80,6 +82,8 @@ const createInitialState = (config) => {
             pathRegex: config["pathRegex-" + i],
             requirePermission: config["requirePermission-" + i],
             prDestinationRegex: config["prDestinationRegex-" + i],
+            ignoreComitters: config["ignoreComitters-" + i],
+            ignoreCommitMsg: config["ignoreCommitMsg-" + i],
         };
         if(newJob.triggers !== null) {
             newJob.triggers = newJob.triggers.replace('pullrequest;', 'propened;prreopened;prsourcerescoped;');

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ParameterizedBuildHook.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ParameterizedBuildHook.java
@@ -135,17 +135,6 @@ public class ParameterizedBuildHook
                         .getDescription());
             }
 
-            PatternSyntaxException ignoreCommittersException = null;
-            try{
-                Pattern.compile(job.getIgnoreComitters());
-            } catch (PatternSyntaxException e){
-                ignoreCommittersException = e;
-            }
-            if(ignoreCommittersException != null) {
-                errors.addFieldError(SettingsService.IGNORE_COMMITTERS_PREFIX + i,
-                        ignoreCommittersException.getDescription());
-            }
-
             PatternSyntaxException ignoreCommitMsgException = null;
             try{
                 Pattern.compile(job.getIgnoreCommitMsg());

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ParameterizedBuildHook.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ParameterizedBuildHook.java
@@ -1,5 +1,6 @@
 package com.kylenicholls.stash.parameterizedbuilds;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -132,6 +133,28 @@ public class ParameterizedBuildHook
             if (pathException != null) {
                 errors.addFieldError(SettingsService.PATH_PREFIX + i, pathException
                         .getDescription());
+            }
+
+            PatternSyntaxException ignoreCommittersException = null;
+            try{
+                Pattern.compile(job.getIgnoreComitters());
+            } catch (PatternSyntaxException e){
+                ignoreCommittersException = e;
+            }
+            if(ignoreCommittersException != null) {
+                errors.addFieldError(SettingsService.IGNORE_COMMITTERS_PREFIX + i,
+                        ignoreCommittersException.getDescription());
+            }
+
+            PatternSyntaxException ignoreCommitMsgException = null;
+            try{
+                Pattern.compile(job.getIgnoreCommitMsg());
+            } catch (PatternSyntaxException e){
+                ignoreCommitMsgException = e;
+            }
+            if(ignoreCommitMsgException != null) {
+                errors.addFieldError(SettingsService.IGNORE_COMMITTERS_PREFIX + i,
+                        ignoreCommitMsgException.getDescription());
             }
         }
     }

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/PushHandler.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/PushHandler.java
@@ -1,5 +1,6 @@
 package com.kylenicholls.stash.parameterizedbuilds.eventHandlers;
 
+import com.atlassian.bitbucket.commit.CommitRequest;
 import com.atlassian.bitbucket.commit.CommitService;
 import com.atlassian.bitbucket.content.AbstractChangeCallback;
 import com.atlassian.bitbucket.content.Change;
@@ -14,8 +15,8 @@ import com.kylenicholls.stash.parameterizedbuilds.helper.SettingsService;
 import com.kylenicholls.stash.parameterizedbuilds.item.BitbucketVariables;
 import com.kylenicholls.stash.parameterizedbuilds.item.Job;
 import com.kylenicholls.stash.parameterizedbuilds.item.Job.Trigger;
-
 import java.io.IOException;
+import java.util.Arrays;
 
 public class PushHandler extends RefHandler {
 
@@ -28,7 +29,8 @@ public class PushHandler extends RefHandler {
 
     @Override
     boolean validateJob(Job job, BitbucketVariables bitbucketVariables) {
-        return super.validateJob(job, bitbucketVariables) && validatePath(job, bitbucketVariables);
+        return super.validateJob(job, bitbucketVariables) && validatePath(job, bitbucketVariables)
+                && validateCommitMsg(job) && validateComitter(job);
     }
 
     boolean validatePath(Job job, BitbucketVariables bitbucketVariables) {
@@ -64,6 +66,37 @@ public class PushHandler extends RefHandler {
                 }
             });
             return false;
+        }
+    }
+
+    boolean validateCommitMsg(Job job) {
+        String ignoreCommitMsg = job.getIgnoreCommitMsg();
+        if(ignoreCommitMsg.isEmpty()){
+            return true;
+        }
+        else{
+            CommitRequest commitRequest = new CommitRequest.Builder(
+                    repository, refChange.getToHash()).build();
+            String actualCommitMsg = commitService.getCommit(commitRequest).getMessage();
+            boolean hasIgnoreMsg = actualCommitMsg != null &&
+                    actualCommitMsg.toLowerCase().contains(ignoreCommitMsg.toLowerCase());
+            return !hasIgnoreMsg;
+        }
+    }
+
+    boolean validateComitter(Job job){
+        String ignoreComitters = job.getIgnoreComitters();
+        if(ignoreComitters.isEmpty()){
+            return true;
+        }
+        else{
+            String[] ignoreComitterList = job.getIgnoreComitters().toLowerCase().split(",");
+            CommitRequest commitRequest = new CommitRequest.Builder(
+                    repository, refChange.getToHash()).build();
+            String author = commitService.getCommit(commitRequest).getAuthor().getName();
+            boolean authorIgnored = Arrays.stream(ignoreComitterList).anyMatch(t ->
+                    t.equals(author.toLowerCase()));
+            return !authorIgnored;
         }
     }
 }

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/PushHandler.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/PushHandler.java
@@ -79,7 +79,7 @@ public class PushHandler extends RefHandler {
                     repository, refChange.getToHash()).build();
             String actualCommitMsg = commitService.getCommit(commitRequest).getMessage();
             boolean hasIgnoreMsg = actualCommitMsg != null &&
-                    actualCommitMsg.toLowerCase().contains(ignoreCommitMsg.toLowerCase());
+                    actualCommitMsg.matches(ignoreCommitMsg);
             return !hasIgnoreMsg;
         }
     }
@@ -90,7 +90,7 @@ public class PushHandler extends RefHandler {
             return true;
         }
         else{
-            String[] ignoreComitterList = job.getIgnoreComitters().toLowerCase().split(",");
+            String[] ignoreComitterList = job.getIgnoreComitters().toLowerCase().split("\\r?\\n");
             CommitRequest commitRequest = new CommitRequest.Builder(
                     repository, refChange.getToHash()).build();
             String author = commitService.getCommit(commitRequest).getAuthor().getName();

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/helper/SettingsService.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/helper/SettingsService.java
@@ -33,6 +33,8 @@ public class SettingsService {
     public static final String PERMISSIONS_PREFIX = "requirePermission-";
     public static final String PRDEST_PREFIX = "prDestinationRegex-";
     public static final String ISPIPELINE_PREFIX = "isPipeline-";
+    public static final String IGNORE_COMMIT_MSG_PREFIX = "ignoreCommitMsg-";
+    public static final String IGNORE_COMMITTERS_PREFIX = "ignoreComitters-";
 
     private RepositoryHookService hookService;
     private SecurityService securityService;
@@ -115,6 +117,11 @@ public class SettingsService {
                         .isPipeline(fetchValue(entry.getKey()
                                         .replace(JOB_PREFIX, ISPIPELINE_PREFIX),
                                 parameterMap, false))
+                        .ignoreComitters(parameterMap.get(entry.getKey()
+                                .replace(JOB_PREFIX, IGNORE_COMMITTERS_PREFIX)).toString())
+                        .ignoreCommitMsg(parameterMap.get(entry.getKey()
+                                .replace(JOB_PREFIX, IGNORE_COMMIT_MSG_PREFIX))
+                                .toString())
                         .build();
 
                 jobsList.add(job);

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/item/Job.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/item/Job.java
@@ -32,6 +32,8 @@ public class Job {
     private final String permissions;
     private final String prDestRegex;
     private final boolean isPipeline;
+    private final String ignoreCommitMsg;
+    private final String ignoreComitters;
 
     private Job(JobBuilder builder) {
         this.jobId = builder.jobId;
@@ -46,6 +48,8 @@ public class Job {
         this.permissions = builder.permissions;
         this.prDestRegex = builder.prDestRegex;
         this.isPipeline = builder.isPipeline;
+        this.ignoreComitters = builder.ignoreComitters;
+        this.ignoreCommitMsg = builder.ignoreCommitMsg;
     }
 
     public int getJobId() {
@@ -94,6 +98,10 @@ public class Job {
 
     public boolean getIsPipeline() { return isPipeline; }
 
+    public String getIgnoreCommitMsg() { return ignoreCommitMsg; }
+
+    public String getIgnoreComitters() { return ignoreComitters; }
+
     public Map<String, Object> asMap(BitbucketVariables bitbucketVariables) {
         Map<String, Object> map = new LinkedHashMap<>();
         map.put("id", jobId);
@@ -128,6 +136,8 @@ public class Job {
         private String permissions;
         private String prDestRegex;
         private boolean isPipeline;
+        private String ignoreCommitMsg;
+        private String ignoreComitters;
 
         public JobBuilder(int jobId) {
             this.jobId = jobId;
@@ -233,6 +243,16 @@ public class Job {
             return this;
         }
 
+        public JobBuilder ignoreComitters(String ignoreComitters){
+            this.ignoreComitters = ignoreComitters;
+            return this;
+        }
+
+        public JobBuilder ignoreCommitMsg(String ignoreCommitMsg){
+            this.ignoreCommitMsg = ignoreCommitMsg;
+            return this;
+        }
+
         public Job build() {
             return new Job(this);
         }
@@ -242,7 +262,8 @@ public class Job {
         return new JobBuilder(jobId).jobName(jobName).jenkinsServer(jenkinsServer).isTag(isTag)
                 .triggers(triggers).token(token).buildParameters(buildParameters)
                 .branchRegex(branchRegex).pathRegex(pathRegex).permissions(permissions)
-                .prDestRegex(prDestRegex).isPipeline(isPipeline);
+                .prDestRegex(prDestRegex).isPipeline(isPipeline)
+                .ignoreCommitMsg(ignoreCommitMsg).ignoreComitters(ignoreComitters);
     }
 
     public String buildUrl(Server jenkinsServer, BitbucketVariables bitbucketVariables,

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/ParameterizedBuildHookTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/ParameterizedBuildHookTest.java
@@ -197,7 +197,7 @@ public class ParameterizedBuildHookTest {
     @Test
     public void testShowErrorIfJobNameEmpty() {
         Job job = new Job.JobBuilder(1).jobName("").jenkinsServer("test").triggers("add".split(";"))
-                .buildParameters("").branchRegex("").pathRegex("").build();
+                .buildParameters("").branchRegex("").pathRegex("").ignoreComitters("").ignoreCommitMsg("").build();
         jobs.add(job);
         buildHook.validate(settings, validationErrors, repositoryScope);
 
@@ -208,7 +208,7 @@ public class ParameterizedBuildHookTest {
     @Test
     public void testShowErrorIfJenkinsServerEmpty() {
         Job job = new Job.JobBuilder(1).jobName("name").jenkinsServer("").triggers("add".split(";"))
-                .buildParameters("").branchRegex("").pathRegex("").build();
+                .buildParameters("").branchRegex("").pathRegex("").ignoreComitters("").ignoreCommitMsg("").build();
         jobs.add(job);
         buildHook.validate(settings, validationErrors, repositoryScope);
 
@@ -219,7 +219,7 @@ public class ParameterizedBuildHookTest {
     @Test
     public void testShowErrorIfTriggersEmpty() {
         Job job = new Job.JobBuilder(1).jobName("name").jenkinsServer("test").triggers("".split(";"))
-                .buildParameters("").branchRegex("").pathRegex("").build();
+                .buildParameters("").branchRegex("").pathRegex("").ignoreComitters("").ignoreCommitMsg("").build();
         jobs.add(job);
         buildHook.validate(settings, validationErrors, repositoryScope);
 
@@ -230,7 +230,8 @@ public class ParameterizedBuildHookTest {
     @Test
     public void testShowErrorIfBranchRegexInvalid() {
         Job job = new Job.JobBuilder(1).jobName("name").jenkinsServer("test")
-                .triggers("add".split(";")).buildParameters("").branchRegex("(").pathRegex("").build();
+                .triggers("add".split(";")).buildParameters("").branchRegex("(").pathRegex("")
+                .ignoreComitters("").ignoreCommitMsg("").build();
         jobs.add(job);
         buildHook.validate(settings, validationErrors, repositoryScope);
 
@@ -241,7 +242,7 @@ public class ParameterizedBuildHookTest {
     @Test
     public void testShowErrorIfPathRegexInvalid() {
         Job job = new Job.JobBuilder(1).jobName("name").jenkinsServer("test").triggers("add".split(";"))
-                .buildParameters("").branchRegex("").pathRegex("(").build();
+                .buildParameters("").branchRegex("").pathRegex("(").ignoreComitters("").ignoreCommitMsg("").build();
         jobs.add(job);
         buildHook.validate(settings, validationErrors, repositoryScope);
 

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/PushHandlerTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/PushHandlerTest.java
@@ -1,5 +1,6 @@
 package com.kylenicholls.stash.parameterizedbuilds.eventHandlers;
 
+import com.atlassian.bitbucket.commit.Commit;
 import com.atlassian.bitbucket.commit.CommitService;
 import com.atlassian.bitbucket.project.Project;
 import com.atlassian.bitbucket.repository.MinimalRef;
@@ -8,6 +9,7 @@ import com.atlassian.bitbucket.repository.RefChangeType;
 import com.atlassian.bitbucket.repository.Repository;
 import com.atlassian.bitbucket.setting.Settings;
 import com.atlassian.bitbucket.user.ApplicationUser;
+import com.atlassian.bitbucket.user.Person;
 import com.kylenicholls.stash.parameterizedbuilds.ciserver.Jenkins;
 import com.kylenicholls.stash.parameterizedbuilds.helper.SettingsService;
 import com.kylenicholls.stash.parameterizedbuilds.item.Job;
@@ -32,6 +34,8 @@ public class PushHandlerTest {
     private final String PROJECT_KEY = "projectkey";
     private final String COMMIT = "commithash";
     private final String url = "http://url";
+    private final String commitMsg = "changes to modify conf skipCI";
+    private final String committer = "admin";
     private final Server projectServer = new Server("projecturl", null, "projectuser", "projecttoken",
             false, false);
     private Settings settings;
@@ -50,8 +54,9 @@ public class PushHandlerTest {
     public void setup() {
         settingsService = mock(SettingsService.class);
         commitService = mock(CommitService.class);
+        Commit commit = mock(Commit.class);
         jenkins = mock(Jenkins.class);
-
+        Person person = mock(Person.class);
         settings = mock(Settings.class);
         refChange = mock(RefChange.class);
         minimalRef = mock(MinimalRef.class);
@@ -72,6 +77,11 @@ public class PushHandlerTest {
                 .pathRegex("").ignoreCommitMsg("").ignoreComitters("");
         jobs = new ArrayList<>();
         when(settingsService.getJobs(any())).thenReturn(jobs);
+        when(commitService.getCommit(any())).thenReturn(commit);
+        when(commit.getMessage()).thenReturn(commitMsg);
+        when(commit.getAuthor()).thenReturn(person);
+        when(person.getName()).thenReturn(committer);
+
     }
 
     @Test
@@ -83,6 +93,54 @@ public class PushHandlerTest {
         spyHandler.run();
 
         verify(spyHandler, times(1)).triggerJenkins(eq(job), any());
+    }
+
+    @Test
+    public void testIgnoreCommitMsgAndJobTriggerIsSkipped (){
+        jobBuilder = new Job.JobBuilder(2).jobName("").buildParameters("").branchRegex("")
+                .pathRegex("").ignoreCommitMsg(".*skipCI.*").ignoreComitters("");
+        Job job = jobBuilder.triggers(new String[] { "push" }).build();
+        jobs.add(job);
+        PushHandler handler = new PushHandler(settingsService, jenkins, commitService, repository, refChange, url, user);
+        PushHandler spyHandler = spy(handler);
+        spyHandler.run();
+        verify(spyHandler, times(0)).triggerJenkins(eq(job), any());
+    }
+
+    @Test
+    public void testIgnoreCommitMsgAndJobIsTriggered (){
+        jobBuilder = new Job.JobBuilder(2).jobName("").buildParameters("").branchRegex("")
+                .pathRegex("").ignoreCommitMsg(".*kuku.*").ignoreComitters("");
+        Job job = jobBuilder.triggers(new String[] { "push" }).build();
+        jobs.add(job);
+        PushHandler handler = new PushHandler(settingsService, jenkins, commitService, repository, refChange, url, user);
+        PushHandler spyHandler = spy(handler);
+        spyHandler.run();
+        verify(spyHandler, times(1)).triggerJenkins(eq(job), any());
+    }
+
+    @Test
+    public void testIgnoreCommittersAndJobIsTriggered (){
+        jobBuilder = new Job.JobBuilder(2).jobName("").buildParameters("").branchRegex("")
+                .pathRegex("").ignoreCommitMsg("").ignoreComitters("ci_user\ntest_user");
+        Job job = jobBuilder.triggers(new String[] { "push" }).build();
+        jobs.add(job);
+        PushHandler handler = new PushHandler(settingsService, jenkins, commitService, repository, refChange, url, user);
+        PushHandler spyHandler = spy(handler);
+        spyHandler.run();
+        verify(spyHandler, times(1)).triggerJenkins(eq(job), any());
+    }
+
+    @Test
+    public void testIgnoreCommittersAndJobTriggerIsSkipped (){
+        jobBuilder = new Job.JobBuilder(2).jobName("").buildParameters("").branchRegex("")
+                .pathRegex("").ignoreCommitMsg("").ignoreComitters("ci_user\nadmin");
+        Job job = jobBuilder.triggers(new String[] { "push" }).build();
+        jobs.add(job);
+        PushHandler handler = new PushHandler(settingsService, jenkins, commitService, repository, refChange, url, user);
+        PushHandler spyHandler = spy(handler);
+        spyHandler.run();
+        verify(spyHandler, times(0)).triggerJenkins(eq(job), any());
     }
 
 }

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/PushHandlerTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/PushHandlerTest.java
@@ -69,7 +69,7 @@ public class PushHandlerTest {
 
         when(minimalRef.getId()).thenReturn(BRANCH_REF);
         jobBuilder = new Job.JobBuilder(1).jobName("").buildParameters("").branchRegex("")
-                .pathRegex("");
+                .pathRegex("").ignoreCommitMsg("").ignoreComitters("");
         jobs = new ArrayList<>();
         when(settingsService.getJobs(any())).thenReturn(jobs);
     }

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/RefHandlerTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/RefHandlerTest.java
@@ -65,7 +65,7 @@ public class RefHandlerTest {
 
         when(minimalRef.getId()).thenReturn(BRANCH_REF);
         jobBuilder = new Job.JobBuilder(1).jobName("").buildParameters("").branchRegex("")
-                .pathRegex("");
+                .pathRegex("").ignoreComitters("").ignoreCommitMsg("");
         jobs = new ArrayList<>();
         when(settingsService.getJobs(any())).thenReturn(jobs);
     }

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/helper/SettingsServiceTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/helper/SettingsServiceTest.java
@@ -43,6 +43,8 @@ public class SettingsServiceTest {
 		String pathRegex = "pathRegex";
 		String permissions = "permissions";
 		String prDestRegex = "prDestinationRegex";
+		String ignoreComitters = "ignoreComitters";
+		String ignoreCommitMsg = "ignoreCommitMsg";
 		Map<String, Object> jobConfig = new LinkedHashMap<>();
 		jobConfig.put(SettingsService.JOB_PREFIX + "0", jobName);
 		jobConfig.put(SettingsService.TRIGGER_PREFIX + "0", triggers);
@@ -52,6 +54,8 @@ public class SettingsServiceTest {
 		jobConfig.put(SettingsService.PATH_PREFIX + "0", pathRegex);
 		jobConfig.put(SettingsService.PERMISSIONS_PREFIX + "0", permissions);
 		jobConfig.put(SettingsService.PRDEST_PREFIX + "0", prDestRegex);
+		jobConfig.put(SettingsService.IGNORE_COMMIT_MSG_PREFIX + "0", ignoreCommitMsg);
+		jobConfig.put(SettingsService.IGNORE_COMMITTERS_PREFIX + "0", ignoreComitters);
 		jobConfig.put(SettingsService.JOB_PREFIX + "1", jobName2);
 		jobConfig.put(SettingsService.TRIGGER_PREFIX + "1", "add");
 		jobConfig.put(SettingsService.PARAM_PREFIX + "1", "");
@@ -60,6 +64,8 @@ public class SettingsServiceTest {
 		jobConfig.put(SettingsService.PATH_PREFIX + "1", "");
 		jobConfig.put(SettingsService.PERMISSIONS_PREFIX + "1", "");
 		jobConfig.put(SettingsService.PRDEST_PREFIX + "1", "");
+		jobConfig.put(SettingsService.IGNORE_COMMIT_MSG_PREFIX + "1", "");
+		jobConfig.put(SettingsService.IGNORE_COMMITTERS_PREFIX + "1", "");
 		List<Job> jobs = settingsService.getJobs(jobConfig);
 
 		List<Trigger> triggerList = Arrays.asList(Trigger.ADD, Trigger.PUSH);
@@ -96,6 +102,8 @@ public class SettingsServiceTest {
 		jobConfig.put(SettingsService.PATH_PREFIX + "0", "");
 		jobConfig.put(SettingsService.PERMISSIONS_PREFIX + "0", "");
 		jobConfig.put(SettingsService.PRDEST_PREFIX + "0", "");
+		jobConfig.put(SettingsService.IGNORE_COMMIT_MSG_PREFIX + "0", "");
+		jobConfig.put(SettingsService.IGNORE_COMMITTERS_PREFIX + "0", "");
 		List<Job> jobs = settingsService.getJobs(jobConfig);
 
 		assertFalse(jobs.get(0).getIsTag());
@@ -113,6 +121,8 @@ public class SettingsServiceTest {
 		jobConfig.put(SettingsService.PATH_PREFIX + "0", "");
 		jobConfig.put(SettingsService.PERMISSIONS_PREFIX + "0", "");
 		jobConfig.put(SettingsService.PRDEST_PREFIX + "0", "");
+		jobConfig.put(SettingsService.IGNORE_COMMIT_MSG_PREFIX + "0", "");
+		jobConfig.put(SettingsService.IGNORE_COMMITTERS_PREFIX + "0", "");
 		List<Job> jobs = settingsService.getJobs(jobConfig);
 
 		assertTrue(jobs.get(0).getIsTag());
@@ -130,6 +140,8 @@ public class SettingsServiceTest {
 		jobConfig.put(SettingsService.PATH_PREFIX + "0", "");
 		jobConfig.put(SettingsService.PERMISSIONS_PREFIX + "0", "");
 		jobConfig.put(SettingsService.PRDEST_PREFIX + "0", "");
+		jobConfig.put(SettingsService.IGNORE_COMMIT_MSG_PREFIX + "0", "");
+		jobConfig.put(SettingsService.IGNORE_COMMITTERS_PREFIX + "0", "");
 		List<Job> jobs = settingsService.getJobs(jobConfig);
 
 		assertTrue(jobs.get(0).getIsPipeline());
@@ -146,6 +158,8 @@ public class SettingsServiceTest {
 		jobConfig.put(SettingsService.PATH_PREFIX + "0", "");
 		jobConfig.put(SettingsService.PERMISSIONS_PREFIX + "0", "");
 		jobConfig.put(SettingsService.PRDEST_PREFIX + "0", "");
+		jobConfig.put(SettingsService.IGNORE_COMMIT_MSG_PREFIX + "0", "");
+		jobConfig.put(SettingsService.IGNORE_COMMITTERS_PREFIX + "0", "");
 		List<Job> jobs = settingsService.getJobs(jobConfig);
 
 		assertTrue(jobs.get(0).getTriggers().contains(Trigger.PROPENED));


### PR DESCRIPTION
#134 
Added to new fields `Ignore Committers` and `Ignore Commits With String` for `PUSH EVENT` trigger.
**Ignore Committers** -- This option can be used to configure the list of users whose commit will not run the automatic CI build.
**Ignore Commits With String** -- Configure string and if it is found in the any commit message, that commit will be ignored and no build will be triggered.

tested the both options and made changes in test cases accordingly.