### PR TITLE
Do not allow forward slash in server alias

### DIFF
--- a/parameterized-client/src/common/rest.js
+++ b/parameterized-client/src/common/rest.js
@@ -20,6 +20,9 @@ export const getJenkinsServers = (context, projectKey) => {
 
 export const saveJenkinsServer = (context, projectKey, serverData) => {
     const baseUrl = getRestUrl(context);
+    if (serverData.alias.includes("/")) {
+        throw "Server nickname cannot include \"/\""
+    }
     const alias = serverData.old_alias !== "" ? serverData.old_alias : serverData.alias;
     let fullUrl = projectKey === "" ?
         `${baseUrl}/global/servers/${alias}` :

--- a/parameterized-client/src/jenkins_settings/server.js
+++ b/parameterized-client/src/jenkins_settings/server.js
@@ -99,6 +99,7 @@ const ServerContainer = ({
                        onChange={(e) => updateServer(serverData.id, "url", e.target.value)}/>
             <TextInput labelText="Server Nickname" id="jenkinsAlias" 
                        required={true} value={serverData.alias}
+                       errorMessage={serverData.alias.includes("/") ? "Nickname cannot contain \"/\"" : "" }
                        onChange={(e) => updateServer(serverData.id, "alias", e.target.value)}/>
             <TextInput labelText="Default User" id="jenkinsUser" 
                        value={serverData.default_user}
@@ -113,6 +114,7 @@ const ServerContainer = ({
             <ButtonGroup>
                 <Button id="saveButton" name="submit" buttonText="Save"
                         extraClasses={["aui-button-primary"]}
+                        disabled={serverData.alias.includes("/")}
                         onClick={saveServer} />
                 <Button id="testButton" name="button" buttonText="Test Jenkins Settings"
                         onClick={testServer}/>

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/rest/ServerService.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/rest/ServerService.java
@@ -101,6 +101,8 @@ public interface ServerService {
 
         if (server.getAlias() == null || server.getAlias().isEmpty()){
             errors.add("Alias required.");
+        } else if (server.getAlias().contains("/")) {
+            errors.add("Alias cannot include \"/\"");
         }
 
         return errors;


### PR DESCRIPTION
Forward slashes in the alias can cause the server definition to become uneditable as brought up in #241. This is because it messes with the rest url in future calls. To prevent this from happening, we should not allow forward slashes to be saved in the first place.

This PR adds checks in both the client and server. The client side validation allows for quicker and easier feedback about the issue while the server side validation prevents rest requests outside of the UI from causing issues.