### PR TITLE
Fix unreleased bug on master

### DIFF
--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/helper/SettingsService.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/helper/SettingsService.java
@@ -117,11 +117,12 @@ public class SettingsService {
                         .isPipeline(fetchValue(entry.getKey()
                                         .replace(JOB_PREFIX, ISPIPELINE_PREFIX),
                                 parameterMap, false))
-                        .ignoreComitters(parameterMap.get(entry.getKey()
-                                .replace(JOB_PREFIX, IGNORE_COMMITTERS_PREFIX)).toString())
-                        .ignoreCommitMsg(parameterMap.get(entry.getKey()
-                                .replace(JOB_PREFIX, IGNORE_COMMIT_MSG_PREFIX))
-                                .toString())
+                        .ignoreComitters(fetchValue(entry.getKey()
+                                        .replace(JOB_PREFIX, IGNORE_COMMITTERS_PREFIX),
+                                parameterMap, ""))
+                        .ignoreCommitMsg(fetchValue(entry.getKey()
+                                        .replace(JOB_PREFIX, IGNORE_COMMIT_MSG_PREFIX),
+                                parameterMap, ""))
                         .build();
 
                 jobsList.add(job);


### PR DESCRIPTION
Upgrading with jobs defined will cause null pointer exceptions. Need to check if these new keys exist before calling toString.