### PR TITLE
Use legacy jenkins settings when needed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.kylenicholls.stash</groupId>
     <artifactId>parameterized-builds</artifactId>
-    <version>4.0.10</version>
+    <version>4.0.11</version>
 
     <organization>
         <name>Kyle Nicholls</name>

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/Jenkins.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/Jenkins.java
@@ -279,13 +279,15 @@ public class Jenkins {
 
     public JenkinsResponse triggerJob(String projectKey, ApplicationUser user, Job job, 
                                       BitbucketVariables bitbucketVariables) {
-        Server jenkinsServer;
-        String joinedUserToken;
-        if (job.getJenkinsServer() != null){
+        Server jenkinsServer = null;
+        String joinedUserToken = null;
+        if (job.getJenkinsServer() != null && !job.getJenkinsServer().isEmpty()){
             jenkinsServer = getJenkinsServer(job.getJenkinsServer());
             joinedUserToken = getJoinedUserToken(user, job.getJenkinsServer());
-        } else {
-            // legacy behaviour
+        }
+
+        //legacy behaviour or the server definition was deleted/changed
+        if (jenkinsServer != null) {
             Server projectServer = getJenkinsServer(projectKey);
             if (projectServer != null){
                 jenkinsServer = projectServer;


### PR DESCRIPTION
This branch is poorly named as it does not solve the issue. However, I don't think we were ever falling back to legacy settings properly. The default value for getJenkinsServer was an empty string and we were only checking for null.

This change should make falling back to legacy settings actually work properly.