### PR TITLE
Properly encode multibranch pipeline job names

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.kylenicholls.stash</groupId>
     <artifactId>parameterized-builds</artifactId>
-    <version>4.0.12</version>
+    <version>4.0.13</version>
 
     <organization>
         <name>Kyle Nicholls</name>


### PR DESCRIPTION
When a branch contains an unencoded char such as `/` the PR based triggers do not trigger the job properly. This fix encodes the branch name before adding it to the build url.