### PR TITLE
Fix issues with no settings present

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.kylenicholls.stash</groupId>
     <artifactId>parameterized-builds</artifactId>
-    <version>5.0.0</version>
+    <version>5.0.1</version>
 
     <organization>
         <name>Kyle Nicholls</name>

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/helper/SettingsService.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/helper/SettingsService.java
@@ -4,10 +4,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import com.atlassian.bitbucket.hook.repository.GetRepositoryHookSettingsRequest;
 import com.atlassian.bitbucket.hook.repository.RepositoryHook;
 import com.atlassian.bitbucket.hook.repository.RepositoryHookService;
+import com.atlassian.bitbucket.hook.repository.RepositoryHookSettings;
 import com.atlassian.bitbucket.permission.Permission;
 import com.atlassian.bitbucket.repository.Repository;
 import com.atlassian.bitbucket.scope.RepositoryScope;
@@ -56,7 +58,9 @@ public class SettingsService {
                             GetRepositoryHookSettingsRequest settingsRequest =
                                     new GetRepositoryHookSettingsRequest.Builder(scope, KEY)
                                             .build();
-                            return hookService.getSettings(settingsRequest).getSettings();
+                            return Optional.ofNullable(hookService.getSettings(settingsRequest))
+                                    .map(RepositoryHookSettings::getSettings)
+                                    .orElse(null);
                         }
                     });
         } catch (Exception e) {

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/rest/BuildResource.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/rest/BuildResource.java
@@ -153,7 +153,6 @@ public class BuildResource extends RestResource {
             Settings settings = settingsService.getSettings(repository);
             if (settings == null) {
                 return Response.ok(Lists.newArrayList()).build();
-                // return Response.status(Response.Status.NOT_FOUND).build();
             }
 
             String projectKey = repository.getProject().getKey();

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/rest/BuildResource.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/rest/BuildResource.java
@@ -46,6 +46,8 @@ import com.kylenicholls.stash.parameterizedbuilds.item.Job.Trigger;
 import com.kylenicholls.stash.parameterizedbuilds.item.Server;
 import com.sun.jersey.spi.resource.Singleton;
 
+import org.apache.commons.compress.utils.Lists;
+
 @Path(ResourcePatterns.REPOSITORY_URI)
 @Consumes({ MediaType.APPLICATION_JSON })
 @Produces({ RestUtils.APPLICATION_JSON_UTF8 })
@@ -150,7 +152,8 @@ public class BuildResource extends RestResource {
         if (authContext.isAuthenticated()) {
             Settings settings = settingsService.getSettings(repository);
             if (settings == null) {
-                return Response.status(Response.Status.NOT_FOUND).build();
+                return Response.ok(Lists.newArrayList()).build();
+                // return Response.status(Response.Status.NOT_FOUND).build();
             }
 
             String projectKey = repository.getProject().getKey();

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/rest/BuildResourceTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/rest/BuildResourceTest.java
@@ -230,7 +230,7 @@ public class BuildResourceTest {
         when(settingsService.getSettings(repository)).thenReturn(null);
         Response actual = rest.getJobs(repository, "branch", "commit", null, 0);
 
-        assertEquals(Response.Status.NOT_FOUND.getStatusCode(), actual.getStatus());
+        assertEquals(Response.Status.OK.getStatusCode(), actual.getStatus());
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Because of the Bitbucket 7 updates around registering extensions, we need to expect that settings may not exist for a repo. This PR adds better null checks and response codes for calls made from repos that do not use the plugin.