### PR TITLE
Fix regex in PR trigger (allow any character in project names)

### DIFF
--- a/src/main/resources/scripts/jenkins/pb-pr-trigger.js
+++ b/src/main/resources/scripts/jenkins/pb-pr-trigger.js
@@ -14,7 +14,7 @@ define('jenkins/parameterized-build-pullrequest', [
     registry
 ) {
     var allJobs;
-    var urlRegex = /(.+?)\/projects\/[\w_ -]+?\/repos\/[\w_ -]+?\/.*/
+    var urlRegex = /(.+?)\/projects\/.+?\/repos\/.+?\/.*/
     var urlParts = window.location.href.match(urlRegex);
 
     function getResourceUrl(context, resourceType){


### PR DESCRIPTION
Adopted the regex used to determine the BitBucket server hostname in order to allow any character in the project's name.
Fixes #289.