### PR TITLE
Allow project-level settings.

### DIFF
--- a/parameterized-client/src/hook/view.js
+++ b/parameterized-client/src/hook/view.js
@@ -10,7 +10,14 @@ window.parameterizedbuilds = window.parameterizedbuilds || {};
 const getJenkinsServers = () => {
     const urlRegex = /(.+?)(\/projects\/.+?\/repos\/.+?\/)settings.*/
     let urlParts = window.location.href.match(urlRegex);
-    let restUrl = urlParts[1] + "/rest/parameterized-builds/latest" + urlParts[2] + "getJenkinsServers";
+    let restUrl = ''
+    if (urlParts !== null) {
+        restUrl = urlParts[1] + "/rest/parameterized-builds/latest" + urlParts[2] + "getJenkinsServers";
+    } else {
+        const urlRegex = /(.+?)(\/projects\/.+?\/)settings.*/
+        urlParts = window.location.href.match(urlRegex);
+        restUrl = urlParts[1] + "/rest/parameterized-builds/latest" + urlParts[2] + "servers";
+    }
     return axios.get(restUrl, {
         timeout: 1000 * 60
     });

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -93,6 +93,10 @@
       <view>parameterizedbuilds.view</view>
       <directory location="/hook/"/>
     </config-form>
+    <scopes>
+        <scope>project</scope>
+        <scope>repository</scope>
+    </scopes>
   </repository-hook>
   
   <!-- Rest resource -->


### PR DESCRIPTION
For #296
When the hook allows it, repositories will default to inheriting the project's settings.
atlassian-plugin.xml add scopes to allow the hook to be configured at the project level.
view.js handle the view happening on either the repository or the project level.